### PR TITLE
Fix syntax error in build_transliteration_mapping

### DIFF
--- a/autoload/esperanto.vim
+++ b/autoload/esperanto.vim
@@ -69,8 +69,6 @@ let s:Mapper = {
 function! s:build_transliteration_mapping(xchar)
     " Mapping for x- and -h transliteration systems.
     let chars_mapping = {"h":"ĥ", "j":"ĵ", "u":"ŭ", "c":"ĉ", "s":"ŝ", "g":"ĝ"}
-    /// .name
-    Child(String)
 
     let mapper = deepcopy(s:Mapper)
     let mapper.modes = ['i', 'c']


### PR DESCRIPTION
There's a syntax error in `build_transliteration_mapping` that appears to have been introduced in the most recent commit. This causes the plugin to fail when using `:Eo`/`EoOn`. This patch fixes it.